### PR TITLE
Fixed URL for tag docs in order slideover

### DIFF
--- a/app/components/OrderEditorSlideover.vue
+++ b/app/components/OrderEditorSlideover.vue
@@ -167,7 +167,7 @@
               <ProseCallout
                 type="tip"
                 icon="i-lucide-tag"
-                to="/docs/tags"
+                to="/docs/features/tags"
               >
                 Add tags to your orders to help organize and categorize them.
               </ProseCallout>


### PR DESCRIPTION
Docs link in order slideover directed to /docs/tags but it should be /docs/features/tags.
